### PR TITLE
Inline clamp dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,11 +2,16 @@
 
 'use strict'
 
-var clamp = require('clamp')
-
 module.exports = toNumber
 module.exports.to = toNumber
 module.exports.from = fromNumber
+
+function clamp(value, min, max) {
+  return min < max
+    ? (value < min ? min : value > max ? max : value)
+    : (value < max ? max : value > min ? min : value)
+}
+
 
 function toNumber (rgba, normalized) {
 	if(normalized == null) normalized = true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "color-id",
   "version": "1.1.0",
-  "lockfileVersion": 1,
-  "dependencies": {
-    "clamp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/clamp/-/clamp-1.0.1.tgz",
-      "integrity": "sha1-ZqDmQBGBbjcZaCj9yMjBRzEshjQ="
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "color-id",
+      "version": "1.1.0",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,8 +19,5 @@
   "bugs": {
     "url": "https://github.com/colorjs/color-id/issues"
   },
-  "homepage": "https://github.com/colorjs/color-id#readme",
-  "dependencies": {
-    "clamp": "^1.0.1"
-  }
+  "homepage": "https://github.com/colorjs/color-id#readme"
 }


### PR DESCRIPTION
The clamp dependency can be inlined, removing the only dependency of this package.


See https://github.com/e18e/ecosystem-issues/issues/252